### PR TITLE
Add maxPoseDetections option

### DIFF
--- a/scratch-vm/src/extensions/scratch3_posenet2scratch/index.js
+++ b/scratch-vm/src/extensions/scratch3_posenet2scratch/index.js
@@ -313,7 +313,7 @@ class Scratch3Posenet2ScratchBlocks {
           this.video.height = 360;
           this.video.autoplay = true;
 
-          this.poseNet = ml5.poseNet(this.video, ()=>{
+          this.poseNet = ml5.poseNet(this.video, {maxPoseDetections: 10}, ()=>{
             console.log('Model Loaded!');
           });
 


### PR DESCRIPTION
人数検知が5人までしかカウントされなかったのでml5.jsのサイトを確認したところ、

> the maximum number of poses to detect. Defaults to 5.
https://learn.ml5js.org/#/reference/posenet?id=maxposedetections

となっていたため、オプション指定で検出数を10に上げてみました。
値を10としたのは、他のブロックのプルダウンが10人までとなっていたためです。
よろしくお願いします。

